### PR TITLE
[KOGITO-3507] Adding custom TrustStore secret attribute to KogitoRuntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# Kogito Operator
+# RHPAM Kogito Operator
+
+The RHPAM Kogito Operator is based on the [Kogito Operator](https://github.com/kiegroup/kogito-operator).
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
+The RHPAM Kogito Operator is based on Kogito Operator. 
+Please, see the upstream [RELEASE NOTES](https://github.com/kiegroup/kogito-operator/blob/master/RELEASE_NOTES.md).
+
+<!-- Remove the comment for any RHPAM JIRA exclusive 
 ## Enhancements  
 
 ## Bug Fixes
 
 ## Known Issues
+-->

--- a/api/v1/kogitoservices.go
+++ b/api/v1/kogitoservices.go
@@ -235,6 +235,13 @@ type KogitoServiceSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=false
 	// +optional
 	Probes KogitoProbe `json:"probes,omitempty"`
+
+	// Custom JKS TrustStore that will be used by this service to make calls to TLS endpoints.
+	// It's expected that the secret has two keys: `keyStorePassword` containing the password for the KeyStore
+	// and `cacerts` containing the binary data of the given KeyStore.
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=false
+	// +optional
+	TrustStoreSecret string `json:"trustStoreSecret,omitempty"`
 }
 
 // GetReplicas ...
@@ -379,4 +386,14 @@ func (k *KogitoServiceSpec) SetProbes(probes api.KogitoProbeInterface) {
 	if newProbes, ok := probes.(*KogitoProbe); ok {
 		k.Probes = *newProbes
 	}
+}
+
+// GetTrustStoreSecret ...
+func (k *KogitoServiceSpec) GetTrustStoreSecret() string {
+	return k.TrustStoreSecret
+}
+
+// SetTrustStoreSecret ...
+func (k *KogitoServiceSpec) SetTrustStoreSecret(trustStoreSecret string) {
+	k.TrustStoreSecret = trustStoreSecret
 }

--- a/bundle/manifests/rhpam.kiegroup.org_kogitoruntimes.yaml
+++ b/bundle/manifests/rhpam.kiegroup.org_kogitoruntimes.yaml
@@ -368,6 +368,9 @@ spec:
                   type: string
                 description: Additional labels to be added to the Service managed by the operator.
                 type: object
+              trustStoreSecret:
+                description: 'Custom JKS TrustStore that will be used by this service to make calls to TLS endpoints. It''s expected that the secret has two keys: `keyStorePassword` containing the password for the KeyStore and `cacerts` containing the binary data of the given KeyStore.'
+                type: string
             type: object
           status:
             description: KogitoRuntimeStatus defines the observed state of KogitoRuntime.

--- a/config/crd/bases/rhpam.kiegroup.org_kogitoruntimes.yaml
+++ b/config/crd/bases/rhpam.kiegroup.org_kogitoruntimes.yaml
@@ -481,6 +481,12 @@ spec:
                 description: Additional labels to be added to the Service managed
                   by the operator.
                 type: object
+              trustStoreSecret:
+                description: 'Custom JKS TrustStore that will be used by this service
+                  to make calls to TLS endpoints. It''s expected that the secret has
+                  two keys: `keyStorePassword` containing the password for the KeyStore
+                  and `cacerts` containing the binary data of the given KeyStore.'
+                type: string
             type: object
           status:
             description: KogitoRuntimeStatus defines the observed state of KogitoRuntime.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/infinispan/infinispan-operator v0.0.0-20210106103300-03aa6d76d1b2
 	github.com/integr8ly/grafana-operator/v3 v3.4.0
 	github.com/keycloak/keycloak-operator v0.0.0-20200917060808-9858b19ca8bf
-	github.com/kiegroup/kogito-operator v0.12.1-0.20210323155633-ba32f4bb70a5
+	github.com/kiegroup/kogito-operator v0.12.1-0.20210326171407-f60a3ec78fcb
 	github.com/mongodb/mongodb-kubernetes-operator v0.3.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,8 @@ github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/keycloak/keycloak-operator v0.0.0-20200917060808-9858b19ca8bf h1:Sfwm3zLvNUHqG8VO96dpAf+MvB4/XkzDhrVtCX+xvwo=
 github.com/keycloak/keycloak-operator v0.0.0-20200917060808-9858b19ca8bf/go.mod h1:8eqyE5GxbqaKEqEy1BgPAo3UaZoJDZ0O9mHv+hBN+F8=
-github.com/kiegroup/kogito-operator v0.12.1-0.20210323155633-ba32f4bb70a5 h1:CrWhswroPG6FKVGic3KprSpirjgAYxXSYzzMCzWclS8=
-github.com/kiegroup/kogito-operator v0.12.1-0.20210323155633-ba32f4bb70a5/go.mod h1:s7IgEpGfN6Blwbsm1nEkGcnQxmSeMWJJeeilfU8cDW8=
+github.com/kiegroup/kogito-operator v0.12.1-0.20210326171407-f60a3ec78fcb h1:dI+04xKcUTNzguTz7psztmsCOMztr7/0Ns6jQDevcXY=
+github.com/kiegroup/kogito-operator v0.12.1-0.20210326171407-f60a3ec78fcb/go.mod h1:s7IgEpGfN6Blwbsm1nEkGcnQxmSeMWJJeeilfU8cDW8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/rhpam-kogito-operator.yaml
+++ b/rhpam-kogito-operator.yaml
@@ -943,6 +943,12 @@ spec:
                 description: Additional labels to be added to the Service managed
                   by the operator.
                 type: object
+              trustStoreSecret:
+                description: 'Custom JKS TrustStore that will be used by this service
+                  to make calls to TLS endpoints. It''s expected that the secret has
+                  two keys: `keyStorePassword` containing the password for the KeyStore
+                  and `cacerts` containing the binary data of the given KeyStore.'
+                type: string
             type: object
           status:
             description: KogitoRuntimeStatus defines the observed state of KogitoRuntime.

--- a/test/framework/kogitobuild.go
+++ b/test/framework/kogitobuild.go
@@ -16,9 +16,9 @@ package framework
 
 import (
 	"fmt"
+	"github.com/kiegroup/kogito-operator/core/kogitobuild"
 
 	"github.com/kiegroup/kogito-operator/api"
-	"github.com/kiegroup/kogito-operator/core/infrastructure"
 	v1 "github.com/kiegroup/rhpam-kogito-operator/api/v1"
 
 	"github.com/kiegroup/kogito-operator/core/framework"
@@ -77,7 +77,7 @@ func getKogitoBuildS2IImage() string {
 		return config.GetBuildS2IImageStreamTag()
 	}
 
-	return getKogitoBuildImage(infrastructure.KogitoBuilderImage)
+	return getKogitoBuildImage(kogitobuild.GetDefaultBuilderImage())
 }
 
 func getKogitoBuildRuntimeImage(kogitoBuild *v1.KogitoBuild) string {
@@ -86,9 +86,9 @@ func getKogitoBuildRuntimeImage(kogitoBuild *v1.KogitoBuild) string {
 		return config.GetBuildRuntimeImageStreamTag()
 	}
 	if kogitoBuild.Spec.Native {
-		imageName = infrastructure.KogitoRuntimeNative
+		imageName = kogitobuild.GetDefaultRuntimeNativeImage()
 	} else {
-		imageName = infrastructure.KogitoRuntimeJVM
+		imageName = kogitobuild.GetDefaultRuntimeJVMImage()
 	}
 	return getKogitoBuildImage(imageName)
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3507

This is related to https://github.com/kiegroup/kogito-operator/pull/811

Small cherry-pick to include the missing attribute for the custom TrustStore.

Also, we were missing some bits from this other PR, which I included here otherwise won't compile: https://github.com/kiegroup/kogito-operator/pull/813/files

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a unit test that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change