### PR TITLE
KOGITO-4851 Prod changes to build in OSBS [1.5.x]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ The RHPAM Kogito Operator is based on the [Kogito Operator](https://github.com/k
 A separate `image-prod.yaml` has been prepared for Productization that **requires CEKit 3.11+**. The `org.kie.kogito.gomoddownloader` module has been replaced with Cachito configuration. Cachito is setup in the OSBS build pod and provides the rhpam-kogito-operator repository at the configured revision along with dependencies so ensure the revision is updated before building.
 
 The image can be built using the following command:
-`cekit --redhat --descriptor image-prod.yaml build osbs`
+
+```bash
+$ cekit --redhat --descriptor image-prod.yaml build osbs```
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 
 The RHPAM Kogito Operator is based on the [Kogito Operator](https://github.com/kiegroup/kogito-operator).
 
+## Productization Requirements
+A separate `image-prod.yaml` has been prepared for Productization that **requires CEKit 3.11+**. The `org.kie.kogito.gomoddownloader` module has been replaced with Cachito configuration. Cachito is setup in the OSBS build pod and provides the rhpam-kogito-operator repository at the configured revision along with dependencies so ensure the revision is updated before building.
+
+The image can be built using the following command:
+`cekit --redhat --descriptor image-prod.yaml build osbs`

--- a/image-prod.yaml
+++ b/image-prod.yaml
@@ -8,13 +8,17 @@
     repositories:
       - path: modules
     install:
-      - name: org.kie.kogito.gomoddownloader
       - name: org.kie.kogito.builder
 
   osbs:
     configuration:
       container:
         image_build_method: imagebuilder
+        remote_source:
+          repo: https://github.com/kiegroup/rhpam-kogito-operator
+          ref: db4a5d18f5f52a64083d8f1bd1776ad60a46904c
+          pkg_managers:
+            - gomod
         platforms:
           only:
             - x86_64
@@ -42,12 +46,6 @@
       dest: /usr/local/bin
 
   osbs:
-    configuration:
-      container:
-        image_build_method: imagebuilder
-        platforms:
-          only:
-            - x86_64
     extra_dir: osbs-extra
     repository:
       name: containers/rhpam-7-kogito-operator

--- a/image.yaml
+++ b/image.yaml
@@ -8,7 +8,6 @@
     repositories:
       - path: modules
     install:
-      - name: org.kie.kogito.gomoddownloader
       - name: org.kie.kogito.builder
 
   osbs:
@@ -45,6 +44,11 @@
     configuration:
       container:
         image_build_method: imagebuilder
+        remote_source:
+          repo: https://github.com/kiegroup/rhpam-kogito-operator
+          ref: db4a5d18f5f52a64083d8f1bd1776ad60a46904c
+          pkg_managers:
+            - gomod
         platforms:
           only:
             - x86_64

--- a/image.yaml
+++ b/image.yaml
@@ -14,6 +14,11 @@
     configuration:
       container:
         image_build_method: imagebuilder
+        remote_source:
+          repo: https://github.com/kiegroup/rhpam-kogito-operator
+          ref: db4a5d18f5f52a64083d8f1bd1776ad60a46904c
+          pkg_managers:
+            - gomod
         platforms:
           only:
             - x86_64
@@ -44,11 +49,6 @@
     configuration:
       container:
         image_build_method: imagebuilder
-        remote_source:
-          repo: https://github.com/kiegroup/rhpam-kogito-operator
-          ref: db4a5d18f5f52a64083d8f1bd1776ad60a46904c
-          pkg_managers:
-            - gomod
         platforms:
           only:
             - x86_64

--- a/image.yaml
+++ b/image.yaml
@@ -46,17 +46,6 @@
       dest: /usr/local/bin
 
   osbs:
-    configuration:
-      container:
-        image_build_method: imagebuilder
-        remote_source:
-          repo: https://github.com/kiegroup/rhpam-kogito-operator
-          ref: db4a5d18f5f52a64083d8f1bd1776ad60a46904c
-          pkg_managers:
-            - gomod
-        platforms:
-          only:
-            - x86_64
     extra_dir: osbs-extra
     repository:
       name: containers/rhpam-7-kogito-operator

--- a/image.yaml
+++ b/image.yaml
@@ -49,6 +49,11 @@
     configuration:
       container:
         image_build_method: imagebuilder
+        remote_source:
+          repo: https://github.com/kiegroup/rhpam-kogito-operator
+          ref: db4a5d18f5f52a64083d8f1bd1776ad60a46904c
+          pkg_managers:
+            - gomod
         platforms:
           only:
             - x86_64

--- a/modules/org.kie.kogito.builder/install.sh
+++ b/modules/org.kie.kogito.builder/install.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
-cd /workspace
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go
-
+if [ -n "$CACHITO_ENV_FILE" ]; then
+  source $CACHITO_ENV_FILE && go build -a -o rhpam-kogito-operator-manager main.go
+  cp $REMOTE_SOURCE_DIR/app/rhpam-kogito-operator-manager /workspace
+else
+  cd /workspace
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go;
+fi


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-4851

Add an `image-prod.yaml` for building in OSBS, main changes are replacing the gomoddownloader module with remote_source configuration that gets injected into the container.yaml. This configuration sets up Cachito in the OSBS pod which packages this repo and explodes it in the pod with deps for building to workaround firewall issues. 
