### PR TITLE
[BXMSPROD-1306] Update to include micro in the version.

### DIFF
--- a/image-bundle.yaml
+++ b/image-bundle.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 name: "rhpam-7/rhpam-kogito-operator-bundle"
 description: "RHPAM Kogito Operator Bundle"
-version: ""7.11.0"
+version: "7.11.0"
 from: "scratch"
 
 labels:

--- a/image-prod.yaml
+++ b/image-prod.yaml
@@ -1,6 +1,6 @@
 - schema_version: 1
   name: "operator-builder"
-  version: ""7.11.0"
+  version: "7.11.0"
   from: "registry.access.redhat.com/ubi8/go-toolset:1.14.12"
   description: "Golang builder image for the RHPAM Kogito Operator"
 
@@ -24,7 +24,7 @@
             - x86_64
 
 - name: "rhpam-7/rhpam-kogito-operator"
-  version: ""7.11.0"
+  version: "7.11.0"
   from: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
   description: "Runtime Image for the RHPAM Kogito Operator"
 

--- a/image.yaml
+++ b/image.yaml
@@ -1,6 +1,6 @@
 - schema_version: 1
   name: "operator-builder"
-  version: ""7.11.0"
+  version: "7.11.0"
   from: "registry.access.redhat.com/ubi8/go-toolset:1.14.12"
   description: "Golang builder image for the RHPAM Kogito Operator"
 
@@ -20,7 +20,7 @@
             - x86_64
 
 - name: "rhpam-7/rhpam-kogito-operator"
-  version: ""7.11.0"
+  version: "7.11.0"
   from: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
   description: "Runtime Image for the RHPAM Kogito Operator"
 

--- a/modules/org.kie.kogito.builder/module.yaml
+++ b/modules/org.kie.kogito.builder/module.yaml
@@ -1,5 +1,5 @@
 name: org.kie.kogito.builder
-version: ""7.11.0"
+version: "7.11.0"
 description: Builds the operator binary
 
 envs:

--- a/modules/org.kie.kogito.bundleinstall/module.yaml
+++ b/modules/org.kie.kogito.bundleinstall/module.yaml
@@ -1,5 +1,5 @@
 name: org.kie.kogito.bundleinstall
-version: ""7.11.0"
+version: "7.11.0"
 description: Copy the bund files to the target image
 
 artifacts:
@@ -12,4 +12,3 @@ artifacts:
   - name: tests-scorecard
     path: "../../../../bundle/tests/scorecard/"
     dest: /tests/scorecard/
-

--- a/modules/org.kie.kogito.gomoddownloader/module.yaml
+++ b/modules/org.kie.kogito.gomoddownloader/module.yaml
@@ -1,5 +1,5 @@
 name: org.kie.kogito.gomoddownloader
-version: ""7.11.0"
+version: "7.11.0"
 description: Download and cache the modules
 artifacts:
   - name: gomod


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/BXMSPROD-1306

QE noticed the version for the Kogito Operator does not include the micro as was included in other images, including the new Kogito images. Updating it for consistency.