### PR TITLE
BDD tests: Use upstream images for builds as a temporary workaround

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,6 +116,10 @@ String getBDDParameters(String image_cache_mode, boolean runtime_app_registry_in
     testParamsMap['runtime_application_image_namespace'] = 'openshift'
     testParamsMap['runtime_application_image_version'] = "pr-\$(echo \${GIT_COMMIT} | cut -c1-7)"
 
+    // Using upstream images as a workaround until there are nightly product images available
+    testParamsMap['build_s2i_image_tag'] = "quay.io/kiegroup/kogito-builder-nightly:latest"
+    testParamsMap['build_runtime_image_tag'] = "quay.io/kiegroup/kogito-runtime-jvm-nightly:latest"
+
     testParamsMap['container_engine'] = env.CONTAINER_ENGINE
 
     String testParams = testParamsMap.collect { entry -> "${entry.getKey()}=\"${entry.getValue()}\"" }.join(' ')

--- a/Jenkinsfile.upstream-operator-sync
+++ b/Jenkinsfile.upstream-operator-sync
@@ -155,6 +155,10 @@ String getBDDParameters(String image_cache_mode, boolean runtime_app_registry_in
     testParamsMap["image_cache_mode"] = image_cache_mode
     testParamsMap['runtime_application_image_registry'] = "quay.io"
     testParamsMap['runtime_application_image_namespace'] = "kiegroup"
+
+    // Using upstream images as a workaround until there are nightly product images available
+    testParamsMap['build_s2i_image_tag'] = "quay.io/kiegroup/kogito-builder-nightly:latest"
+    testParamsMap['build_runtime_image_tag'] = "quay.io/kiegroup/kogito-runtime-jvm-nightly:latest"
     
     testParamsMap['container_engine'] = env.CONTAINER_ENGINE
 


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

https://github.com/kiegroup/rhpam-kogito-operator/pull/36 adjusted default images to use product ones. However as they aren't available yet we need to keep using upstream images as a temporary workaround for sync check.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change