### PR TITLE
[KOGITO-5460] Change com.redhat.openshift.versions

### DIFF
--- a/image-bundle.yaml
+++ b/image-bundle.yaml
@@ -40,7 +40,7 @@ labels:
   - name: com.redhat.delivery.operator.bundle
     value: "true"
   - name: com.redhat.openshift.versions
-    value: v4.6,v4.7
+    value: v4.6
 
 modules:
   repositories:


### PR DESCRIPTION
Change the `com.redhat.openshift.versions` label to satisfy CFC Delivery rules otherwise it fails validation before pushing

https://issues.redhat.com/browse/KOGITO-5460
1.5.x: https://github.com/kiegroup/rhpam-kogito-operator/pull/50

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change