### PR TITLE
RHPAM-3777 Allow to update prod version

### DIFF
--- a/.github/workflows/Kogito-Operator-PR-Check.yaml
+++ b/.github/workflows/Kogito-Operator-PR-Check.yaml
@@ -82,5 +82,7 @@ jobs:
         run: |
           git clone https://github.com/bats-core/bats-core.git
           cd bats-core && ./install.sh $HOME
+      - name: Install Operator-sdk
+        run: ./hack/ci/install-operator-sdk.sh
       - name: Run Bats
         run: $HOME/bin/bats hack/*.bats

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -94,7 +94,7 @@ void setupProdUpdateVersionJob(String jobFolder) {
         }
 
         environmentVariables {
-            env('REPO_NAME', 'kogito-images')
+            env('REPO_NAME', 'rhpam-kogito-operator')
 
             env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
             env('BUILD_BRANCH_NAME', "${GIT_BRANCH}")

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -1,7 +1,6 @@
 import org.kie.jenkins.jobdsl.templates.KogitoJobTemplate
 import org.kie.jenkins.jobdsl.KogitoConstants
 import org.kie.jenkins.jobdsl.Utils
-import org.kie.jenkins.jobdsl.KogitoJobType
 
 boolean isMainBranch() {
     return "${GIT_BRANCH}" == "${GIT_MAIN_BRANCH}"
@@ -35,16 +34,16 @@ def getJobParams(String jobName, String jobFolder, String jenkinsfileName, Strin
 
 def nightlyBranchFolder = "${KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER}/${JOB_BRANCH_FOLDER}"
 
-if (isMainBranch()) {
+// if (isMainBranch()) {
     // PR job is disabled for now as handled by another Jenkins
     // folder(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
 
     // setupPrJob(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
-}
+// }
 
-folder(KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER)
-folder(nightlyBranchFolder)
-setupSyncJob(nightlyBranchFolder, KogitoJobType.NIGHTLY)
+setupSyncJob(nightlyBranchFolder)
+
+setupProdUpdateVersionJob("${KogitoConstants.KOGITO_DSL_TOOLS_FOLDER}/${JOB_BRANCH_FOLDER}")
 
 /////////////////////////////////////////////////////////////////
 // Methods
@@ -57,7 +56,7 @@ void setupPrJob(String jobFolder) {
 }
 
 
-void setupSyncJob(String jobFolder, KogitoJobType jobType) {
+void setupSyncJob(String jobFolder) {
     def jobParams = getJobParams('rhpam-kogito-operator-sync', jobFolder, 'Jenkinsfile.upstream-operator-sync', 'RHPAM Kogito Operator synchronizing with Kogito operator')
     jobParams.triggers = [ cron : '@midnight' ]
     KogitoJobTemplate.createPipelineJob(this, jobParams).with {
@@ -82,6 +81,28 @@ void setupSyncJob(String jobFolder, KogitoJobType jobType) {
             env('OPENSHIFT_REGISTRY_KEY', 'OPENSHIFT_REGISTRY')
 
             env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
+        }
+    }
+}
+
+void setupProdUpdateVersionJob(String jobFolder) {
+    KogitoJobTemplate.createPipelineJob(this, getJobParams('rhpam-kogito-operator-update-prod-version', jobFolder, 'Jenkinsfile.update-prod-version', 'Update prod version for RHPAM Kogito Operator')).with {
+        parameters {
+            stringParam('PROD_PROJECT_VERSION', '', 'Which version to set ?')
+            stringParam('PROD_BUNDLE_SUFFIX', '', '(Optional) Bundle suffix to apply to the version ? Default is value `1`.')
+            stringParam('PROD_REPLACES_VERSION', '', '(Optional) Which version does it replaces ? If not given, no replacement will be done.')
+        }
+
+        environmentVariables {
+            env('REPO_NAME', 'kogito-images')
+
+            env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
+            env('BUILD_BRANCH_NAME', "${GIT_BRANCH}")
+
+            env('AUTHOR_CREDS_ID', "${GIT_AUTHOR_CREDENTIALS_ID}")
+            env('GITHUB_TOKEN_CREDS_ID', "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}")
+            env('GIT_AUTHOR_BOT', "${GIT_BOT_AUTHOR_NAME}")
+            env('BOT_CREDENTIALS_ID', "${GIT_BOT_AUTHOR_CREDENTIALS_ID}")
         }
     }
 }

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -88,6 +88,8 @@ void setupSyncJob(String jobFolder) {
 void setupProdUpdateVersionJob(String jobFolder) {
     KogitoJobTemplate.createPipelineJob(this, getJobParams('rhpam-kogito-operator-update-prod-version', jobFolder, 'Jenkinsfile.update-prod-version', 'Update prod version for RHPAM Kogito Operator')).with {
         parameters {
+            stringParam('JIRA_NUMBER', '', 'KIECLOUD-XXX or RHPAM-YYYY or else. This will be added to the commit and PR.')
+            
             stringParam('PROD_PROJECT_VERSION', '', 'Which version to set ?')
             stringParam('PROD_BUNDLE_SUFFIX', '', '(Optional) Bundle suffix to apply to the version ? Default is value `1`.')
             stringParam('PROD_REPLACES_VERSION', '', '(Optional) Which version does it replaces ? If not given, no replacement will be done.')

--- a/Jenkinsfile.update-prod-version
+++ b/Jenkinsfile.update-prod-version
@@ -48,10 +48,10 @@ pipeline {
                 script {
                     String command = "./hack/bump-version.sh ${getProdProjectVersion()}"
                     if(getProdBundleSuffix()) {
-                        command += "-b ${getProdBundleSuffix()}"
+                        command += " -b ${getProdBundleSuffix()}"
                     }
                     if(getProdReplacesVersion()) {
-                        command += "-b ${getProdReplacesVersion()}"
+                        command += " -r ${getProdReplacesVersion()}"
                     }
 
                     sh command

--- a/Jenkinsfile.update-prod-version
+++ b/Jenkinsfile.update-prod-version
@@ -23,8 +23,6 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    clean()
-
                     assert getProdProjectVersion()
 
                     currentBuild.displayName = getProdProjectVersion()
@@ -48,7 +46,15 @@ pipeline {
             }
             steps {
                 script {
-                    sh "./hack/bump-version.sh ${getProdProjectVersion()}"
+                    String command = "./hack/bump-version.sh ${getProdProjectVersion()}"
+                    if(getProdBundleSuffix()) {
+                        command += "-b ${getProdBundleSuffix()}"
+                    }
+                    if(getProdReplacesVersion()) {
+                        command += "-b ${getProdReplacesVersion()}"
+                    }
+
+                    sh command
 
                     if (githubscm.isThereAnyChanges()) {
                         githubscm.commitChanges("Update prod version to ${getProdProjectVersion()}")

--- a/Jenkinsfile.update-prod-version
+++ b/Jenkinsfile.update-prod-version
@@ -24,6 +24,7 @@ pipeline {
             steps {
                 script {
                     assert getProdProjectVersion()
+                    assert getJiraNumber()
 
                     currentBuild.displayName = getProdProjectVersion()
 
@@ -55,20 +56,21 @@ pipeline {
                     }
 
                     sh command
-
-                    if (githubscm.isThereAnyChanges()) {
-                        githubscm.commitChanges("Update prod version to ${getProdProjectVersion()}")
-                    } else {
-                        error 'No update version can be done'
-                    }
                 }
             }
         }
         stage('Create PR') {
             steps {
                 script {
+                    String commitMsg = "[${getJiraNumber()}] Update product version to ${getProdProjectVersion()}"
+                    if (githubscm.isThereAnyChanges()) {
+                        githubscm.commitChanges(commitMsg)
+                    } else {
+                        error 'No update version can be done'
+                    }
+
                     githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
-                    String prLink = githubscm.createPR("Update prod version to ${getProdProjectVersion()}", 'Please review and merge', getBuildBranch(), getBotAuthorCredsID())
+                    String prLink = githubscm.createPR(commitMsg, 'Please review and merge', getBuildBranch(), getBotAuthorCredsID())
 
                     echo "Created PR ${prLink}"
                 }
@@ -116,4 +118,8 @@ String getProdBundleSuffix() {
 
 String getProdReplacesVersion() {
     return "${PROD_REPLACES_VERSION}"
+}
+
+String getJiraNumber() {
+    return "${JIRA_NUMBER}"
 }

--- a/Jenkinsfile.update-prod-version
+++ b/Jenkinsfile.update-prod-version
@@ -1,0 +1,113 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && !master'
+    }
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
+    // parameters {
+    // For parameters, check into .jenkins/dsl/jobs.groovy file
+    // }
+
+    environment {
+        // Static env is defined into .jenkins/dsl/jobs.groovy file
+
+        BOT_BRANCH_HASH = "${util.generateHash(10)}"
+    }
+
+    stages {
+        stage('Initialization') {
+            steps {
+                script {
+                    clean()
+
+                    assert getProdProjectVersion()
+
+                    currentBuild.displayName = getProdProjectVersion()
+
+                    deleteDir()
+                    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
+                }
+            }
+        }
+        stage('Prepare for PR') {
+            steps {
+                script {
+                    githubscm.forkRepo(getBotAuthorCredsID())
+                    githubscm.createBranch(getBotBranch())
+                }
+            }
+        }
+        stage('Update prod version') {
+            when {
+                expression { return getProdProjectVersion() != '' }
+            }
+            steps {
+                script {
+                    sh "./hack/bump-version.sh ${getProdProjectVersion()}"
+
+                    if (githubscm.isThereAnyChanges()) {
+                        githubscm.commitChanges("Update prod version to ${getProdProjectVersion()}")
+                    } else {
+                        error 'No update version can be done'
+                    }
+                }
+            }
+        }
+        stage('Create PR') {
+            steps {
+                script {
+                    githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
+                    String prLink = githubscm.createPR("Update prod version to ${getProdProjectVersion()}", 'Please review and merge', getBuildBranch(), getBotAuthorCredsID())
+
+                    echo "Created PR ${prLink}"
+                }
+            }
+        }
+    }
+    post {
+        cleanup {
+            cleanWs()
+        }
+    }
+}
+
+String getRepoName() {
+    return "${REPO_NAME}"
+}
+
+String getBuildBranch() {
+    return "${BUILD_BRANCH_NAME}"
+}
+
+String getGitAuthor() {
+    return "${GIT_AUTHOR}"
+}
+
+String getBotBranch() {
+    return "${getProdProjectVersion() ?: getBuildBranch()}-${env.BOT_BRANCH_HASH}"
+}
+
+String getBotAuthor() {
+    return "${GIT_AUTHOR_BOT}"
+}
+
+String getBotAuthorCredsID() {
+    return "${BOT_CREDENTIALS_ID}"
+}
+
+String getProdProjectVersion() {
+    return "${PROD_PROJECT_VERSION}"
+}
+
+String getProdBundleSuffix() {
+    return "${PROD_BUNDLE_SUFFIX}"
+}
+
+String getProdReplacesVersion() {
+    return "${PROD_REPLACES_VERSION}"
+}

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -13,24 +13,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source ./hack/env.sh
+script_dir_path=`dirname "${BASH_SOURCE[0]}"`
+source ${script_dir_path}/env.sh
 
-old_version=$(getOperatorVersion)
-new_version=$1
+SCRIPT_NAME=`basename $0`
 
-if [ -z "$new_version" ]; then
+function usage(){
+  printf "Update the version of the operator."
+  printf "\n"
+  printf "\n${SCRIPT_NAME} [options]* version"
+  printf "\n"
+  printf "\nOptions:"
+  printf "\n"
+  printf "\n-h | --help\n\tPrint the usage of this script."
+  printf "\n-r | --replaces\n\tOperator Version to replace in csv."
+  printf "\n-b | --bundle-suffix\n\tBundle suffix to apply. Default is `1`."
+  printf "\n"
+  printf "\nExample:"
+  printf "\n"
+  printf "\n# Update the version to 7.12.0"
+  printf "\n\n\t${SCRIPT_NAME} 7.12.0"
+  printf "\n"
+  printf "\n# Update the version to 7.12.0 with bundle suffix `2` and version 7.11.1 replaced"
+  printf "\n\n\t${SCRIPT_NAME} 7.12.0 -r 7.11.1 -b 2"
+  printf "\n"
+  printf "\n"
+}
+
+function update_csv_file(){
+  local csvFile=$1
+  local versionToReplace=$2
+  local bundleVersion="${new_version}-${bundle_version_suffix}"
+  echo "Update ${csvFile} replacing ${versionToReplace} with bundle version ${bundleVersion} and replaces_version ${replaces_version}"
+  sed -i "s/rhpam-kogito-operator\.v${versionToReplace}.*/rhpam-kogito-operator.v${bundleVersion}/g" "${csvFile}"
+  sed -i "s/rhpam-kogito-operator\.${versionToReplace}.*/rhpam-kogito-operator.${bundleVersion}/g" "${csvFile}"
+  sed -i "s/version: ${versionToReplace}.*/version: ${bundleVersion}/g" "${csvFile}"
+  if [ ! -z $replaces_version ]; then
+    sed -i "s|replaces: rhpam-kogito-operator.*|replaces: rhpam-kogito-operator.v${replaces_version}|g" "${csvFile}"
+  fi
+}
+
+new_version=
+replaces_version=
+bundle_version_suffix='1'
+
+while (( $# ))
+do
+case $1 in
+  -r|--replaces)
+    shift
+    replaces_version=$1
+  ;;
+  -b|--bundle-suffix)
+    shift
+    bundle_version_suffix=$1
+  ;;
+  -h|--help)
+    usage
+    exit 0
+  ;;
+  *)
+    new_version=$1
+  ;;
+esac
+shift
+done
+
+if [ -z "${new_version}" ]; then
   echo "Please inform the new version. Use X.X.X"
   exit 1
 fi
 
-sed -i "s/$old_version/$new_version/g" README.md version/version.go config/manager/kustomization.yaml Makefile image*.yaml modules/**/module.yaml
+echo "Set version ${new_version} with bundle suffix ${bundle_version_suffix} and replacing version (if not empty) ${replaces_version}"
+
+old_version=$(getOperatorVersion)
+
+sed -i "s/${old_version}/${new_version}/g" README.md version/version.go config/manager/kustomization.yaml Makefile image*.yaml modules/**/module.yaml
 
 make vet
 
-# replace in csv file
-sed -i "s|replaces: rhpam-kogito-operator.*|replaces: rhpam-kogito-operator.v$(getLatestOlmReleaseVersion)|g" "$(getCsvFile)"
-sed -i "s/$old_version/$new_version/g" "$(getCsvFile)"
+update_csv_file $(getCsvFile) ${old_version}
 
 make bundle
+
+update_csv_file $(getBundleCsvFile) ${new_version}
 
 echo "Version bumped from $old_version to $new_version"

--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -23,7 +23,7 @@ if [ -z "$new_version" ]; then
   exit 1
 fi
 
-sed -i "s/$old_version/$new_version/g" README.md version/version.go config/manager/kustomization.yaml Makefile
+sed -i "s/$old_version/$new_version/g" README.md version/version.go config/manager/kustomization.yaml Makefile image*.yaml modules/**/module.yaml
 
 make vet
 
@@ -32,8 +32,5 @@ sed -i "s|replaces: rhpam-kogito-operator.*|replaces: rhpam-kogito-operator.v$(g
 sed -i "s/$old_version/$new_version/g" "$(getCsvFile)"
 
 make bundle
-
-# rewrite test default config, all other configuration into the file will be overridden
-#./hack/update_test_config.sh
 
 echo "Version bumped from $old_version to $new_version"

--- a/hack/bump-version.sh.bats
+++ b/hack/bump-version.sh.bats
@@ -31,8 +31,8 @@ teardown() {
     [[ "${output}" =~ "Please inform the new version. Use X.X.X" ]]
 }
 
-@test "check csv file is set correctly" {
-    export -f make
+@test "check csv file is set correctly, no option" {
+    # export -f make
 
     dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
     cd ${dir}
@@ -41,10 +41,67 @@ teardown() {
 
     # Check csv file
     [[ "${output}" =~ "Version bumped from ${CURRENT_VERSION} to ${NEW_VERSION}" ]]
+    [[ "${output}" =~ "Set version ${NEW_VERSION} with bundle suffix 1 and replacing version (if not empty) " ]]
     # fine tune results
     csv_file=$(cat $(getCsvFile))
-    # [[ "${csv_file}" =~ "replaces: rhpam-kogito-operator.v${getLatestOlmReleaseVersion}" ]]
-    [[ "${csv_file}" =~ "version: ${NEW_VERSION}" ]]
-    [[ "${csv_file}" =~ "operated-by: rhpam-kogito-operator.${NEW_VERSION}" ]]
-    [[ "${csv_file}" =~ "registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${csv_file}" =~ "containerImage: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${csv_file}" =~ "name: rhpam-kogito-operator.v${NEW_VERSION}-1" ]]
+    [[ "${csv_file}" =~ "operated-by: rhpam-kogito-operator.${NEW_VERSION}-1" ]]
+    [[ "${csv_file}" =~ "version: ${NEW_VERSION}-1" ]]
+    bundle_csv_file=$(cat $(getBundleCsvFile))
+    [[ "${bundle_csv_file}" =~ "containerImage: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${bundle_csv_file}" =~ "name: rhpam-kogito-operator.v${NEW_VERSION}-1" ]]
+    [[ "${bundle_csv_file}" =~ "image: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${bundle_csv_file}" =~ "operated-by: rhpam-kogito-operator.${NEW_VERSION}-1" ]]
+    [[ "${bundle_csv_file}" =~ "version: ${NEW_VERSION}-1" ]]
+}
+
+@test "check csv file is set correctly with bundle suffix" {
+    # export -f make
+
+    dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
+    cd ${dir}
+    run hack/bump-version.sh ${NEW_VERSION} -b 3
+    [ "$status" -eq 0 ]
+
+    # Check csv file
+    [[ "${output}" =~ "Version bumped from ${CURRENT_VERSION} to ${NEW_VERSION}" ]]
+    [[ "${output}" =~ "Set version ${NEW_VERSION} with bundle suffix 3 and replacing version (if not empty) " ]]
+    # fine tune results
+    csv_file=$(cat $(getCsvFile))
+    [[ "${csv_file}" =~ "containerImage: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${csv_file}" =~ "name: rhpam-kogito-operator.v${NEW_VERSION}-3" ]]
+    [[ "${csv_file}" =~ "operated-by: rhpam-kogito-operator.${NEW_VERSION}-3" ]]
+    [[ "${csv_file}" =~ "version: ${NEW_VERSION}-3" ]]
+    bundle_csv_file=$(cat $(getBundleCsvFile))
+    [[ "${bundle_csv_file}" =~ "containerImage: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${bundle_csv_file}" =~ "name: rhpam-kogito-operator.v${NEW_VERSION}-3" ]]
+    [[ "${bundle_csv_file}" =~ "image: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${bundle_csv_file}" =~ "operated-by: rhpam-kogito-operator.${NEW_VERSION}-3" ]]
+    [[ "${bundle_csv_file}" =~ "version: ${NEW_VERSION}-3" ]]
+}
+
+@test "check csv file is set correctly with bundle suffix and replaces version" {
+    # export -f make
+
+    dir="${BATS_TMPDIR}/${BATS_TEST_NAME}"
+    cd ${dir}
+    run hack/bump-version.sh ${NEW_VERSION} -b 10 -r 7.11.1
+    [ "$status" -eq 0 ]
+
+    # Check csv file
+    [[ "${output}" =~ "Version bumped from ${CURRENT_VERSION} to ${NEW_VERSION}" ]]
+    [[ "${output}" =~ "Set version ${NEW_VERSION} with bundle suffix 10 and replacing version (if not empty) " ]]
+    # fine tune results
+    csv_file=$(cat $(getCsvFile))
+    [[ "${csv_file}" =~ "containerImage: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${csv_file}" =~ "name: rhpam-kogito-operator.v${NEW_VERSION}-10" ]]
+    [[ "${csv_file}" =~ "operated-by: rhpam-kogito-operator.${NEW_VERSION}-10" ]]
+    [[ "${csv_file}" =~ "version: ${NEW_VERSION}-10" ]]
+    bundle_csv_file=$(cat $(getBundleCsvFile))
+    [[ "${bundle_csv_file}" =~ "containerImage: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${bundle_csv_file}" =~ "name: rhpam-kogito-operator.v${NEW_VERSION}-10" ]]
+    [[ "${bundle_csv_file}" =~ "image: registry.stage.redhat.io/rhpam-7/rhpam-kogito-rhel8-operator:${NEW_VERSION}" ]]
+    [[ "${bundle_csv_file}" =~ "operated-by: rhpam-kogito-operator.${NEW_VERSION}-10" ]]
+    [[ "${bundle_csv_file}" =~ "version: ${NEW_VERSION}-10" ]]
 }

--- a/hack/env.sh
+++ b/hack/env.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 CSV_DIR="config/manifests/bases"
+BUNDLE_CSV_DIR="bundle/manifests"
 TEST_CONFIG_FILE="test/.default_config"
 
 getOperatorVersion() {
@@ -30,4 +31,8 @@ getLatestOlmReleaseVersion() {
 
 getCsvFile() {
   echo "${CSV_DIR}/rhpam-kogito-operator.clusterserviceversion.yaml"
+}
+
+getBundleCsvFile() {
+  echo "${BUNDLE_CSV_DIR}/rhpam-kogito-operator.clusterserviceversion.yaml"
 }


### PR DESCRIPTION
Inspired by this PR: https://github.com/kiegroup/rhpam-kogito-operator/pull/52

**Example generated PR: https://github.com/radtriste/rhpam-kogito-operator/pull/2**

For LTS branch, job will be available under `/KIE/kogito/tools/{branch}/rhpam-kogito-operator-update-prod-version` and will require those parameters:
- `PROD_PROJECT_VERSION` this is the targeted product version
- `PROD_BUNDLE_SUFFIX` bundle number which will be added to the name. Default (if empty) is value `1`.
- `PROD_REPLACES_VERSION` which version do we want to replace ? Even if it seems the `replaces` field is not generated anymore... not sure why ...

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors' guide](https://github.com/kiegroup/kogito-operator/blob/master/README.md#contributing-to-the-kogito-operator)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains a link to the JIRA issue
- [ ] Pull Request contains a description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change