### PR TITLE
Update to replaces and reference initial 7.11.0 build

### DIFF
--- a/bundle/manifests/rhpam-kogito-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhpam-kogito-operator.clusterserviceversion.yaml
@@ -356,5 +356,5 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  replaces: rhpam-kogito-operator.v7.11.0-1
+  replaces: rhpam-kogito-operator.v7.11.0
   version: 7.11.1-1

--- a/config/manifests/bases/rhpam-kogito-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhpam-kogito-operator.clusterserviceversion.yaml
@@ -79,5 +79,5 @@ spec:
   maturity: beta
   provider:
     name: Red Hat
-  replaces: rhpam-kogito-operator.v7.11.0-1
+  replaces: rhpam-kogito-operator.v7.11.0
   version: 7.11.1-1


### PR DESCRIPTION
Update the replaces field to reference the initial 7.11.0 build due to an OLM bug meaning it didn't get pushed.