### PR TITLE
[KOGITO-6230] remove OS and ARCH to have multiarch build

### DIFF
--- a/modules/org.kie.kogito.builder/install.sh
+++ b/modules/org.kie.kogito.builder/install.sh
@@ -6,5 +6,5 @@ if [ -n "$CACHITO_ENV_FILE" ]; then
   cp $REMOTE_SOURCE_DIR/app/rhpam-kogito-operator-manager /workspace
 else
   cd /workspace
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go;
+  CGO_ENABLED=0 GO111MODULE=on go build -a -o rhpam-kogito-operator-manager main.go;
 fi


### PR DESCRIPTION
.com/kiegroup/kogito-operator/blob/main/README.md#contributing-to-the-kogito-operator)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a unit test that verifies it
- [ ] You've ran `make before-pr` and everything is working accordingly
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](https://github.com/kiegroup/kogito-operator/blob/main/RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
﻿golang automatically compiles natively, and explicitly setting these
prevents multi-architecture builds from working.
</summary>

* <b>Run operator BDD testing</b>
  Please add comment: <b>/jenkins test</b>

* <b>Run RHPAM operator BDD testing</b>
  Please add comment: <b>/jenkins RHPAM test</b>
</details>